### PR TITLE
Enable to use external scripts

### DIFF
--- a/lib/ng-index.js
+++ b/lib/ng-index.js
@@ -2,6 +2,7 @@
 
 var through  = require('through2');
 var template = require('lodash.template');
+var _        = require('lodash');
 var path     = require('path');
 var fs       = require('fs');
 var File     = require('vinyl');
@@ -13,12 +14,13 @@ function ngIndex(opts) {
         opts = { main: opts };
     }
 
-    var tplData = {
-        main: opts.main,
-        base: opts.base,
+    var tplData = _.assign({
+        main: '',
+        base: '',
         scripts: [],
+        external_scripts: [],
         styles: []
-    };
+    }, opts);
 
     return through.obj(ngIndexTransform, ngIndexFlush);
 

--- a/tpl/index.template.html
+++ b/tpl/index.template.html
@@ -16,6 +16,8 @@
 %>        <base href="<%= base %>">
 <% } %><% styles.forEach(function(href) {
 %>        <link rel="stylesheet" href="<%= href %>">
+<% }) %><% external_scripts.forEach(function(src) {
+%>        <script src="<%= src %>"></script>
 <% }) %><% scripts.forEach(function(src) {
 %>        <script src="<%= src %>"></script>
 <% }) %>    </head>


### PR DESCRIPTION
Enable to add js not includable in bower components

``` js
.pipe(ngIndex({
            main: 'we.bootstrap',
            external_scripts: [
                'http://localhost:8000/socket.io/socket.io.js'
            ]
        }))
```
