### PR TITLE
Enable to catch errors in ngStyle without breaking style

### DIFF
--- a/lib/ng-style.js
+++ b/lib/ng-style.js
@@ -42,7 +42,7 @@ function ngStyle(opts) {
         }
 
         function error(error) {
-            throw new Error(error.message + dirname);
+            done(error.message + dirname, null);
         }
     }
 }


### PR DESCRIPTION
With that fix can catch errors in watch when got a scss error and do :

```
gulp.task('ng-styles', [clean('css')], function(done) {
    return gulp
        .src('src/bootstrap/module.scss')
        .pipe(plumber())
        .pipe(ngStyle())
        .on('error', function (error) {
            done(error);
        })
        .pipe(rename({ basename: 'ionic.app', extname: '.css' }))
        .pipe(gulp.dest('www/css/'))
        .pipe(reload({ stream: true }));
});
```
