### PR TITLE
Fix lodash.template version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "camel-case": "^1.1.1",
     "gulp": "^3.8.11",
     "jshint": "^2.6.3",
-    "lodash.template": "^3.3.0",
+    "lodash.template": "3.6.0",
     "node-sass": "^2.0.1",
     "rcfinder": "^0.1.8",
     "through2": "^0.6.3",


### PR DESCRIPTION
Bug with lodash.template@3.6.2 and ng-build:

SyntaxError: Unexpected number
    at Function (<anonymous>)
    at workspace/node_modules/ng-build/node_modules/lodash.template/index.js:349:12
    at workspace/node_modules/ng-build/node_modules/lodash.template/index.js:383:17
    at workspace/node_modules/ng-build/node_modules/lodash.template/node_modules/lodash.restparam/index.js:54:27
    at template (workspace/node_modules/ng-build/node_modules/lodash.template/index.js:348:16)
    at render (workspace/node_modules/ng-build/lib/ng-wrap.js:23:23)
    at fs.js:272:14
    at workspace/node_modules/bower/node_modules/bower-json/node_modules/graceful-fs/graceful-fs.js:104:5
    at workspace/node_modules/bower/node_modules/bower-registry-client/node_modules/graceful-fs/graceful-fs.js:104:5
    at workspace/node_modules/bower/node_modules/bower-config/node_modules/graceful-fs/graceful-fs.js:104:5
