### PR TITLE
Enable to use //@Canonical(name) to force named used

### DIFF
--- a/lib/ng-wire.js
+++ b/lib/ng-wire.js
@@ -49,6 +49,11 @@ function ngWire() {
 
             provider.name = camelCase(module.name + '.' + provider.name);
 
+            var ret = provider.contents.match(/\/\/@Canonical\((.+)\)/);
+            if (ret) {
+                provider.name = ret[1];
+            }
+            
             if (provider.type === 'controller') {
                 provider.name = [
                     provider.name.charAt(0).toUpperCase(),


### PR DESCRIPTION
```
directive("name", ["$state", function mentioTag($state) {
//@Canonical(name)
```

instead of 

```
.directive("myModuleName", ["$state", function mentioTag($state) {
```
