### PR TITLE
fix sass

### DIFF
--- a/lib/ng-style.js
+++ b/lib/ng-style.js
@@ -33,6 +33,12 @@ function ngStyle(opts) {
             includePaths: paths,
             imagePath: module.imagePath,
             // outputStyle: 'compressed'
+        }, function nodeCallback(error, result) {
+          if (error) {
+            error(error);
+          } else {
+            success(result);
+          }
         });
 
         function success(results) {

--- a/lib/ng-style.js
+++ b/lib/ng-style.js
@@ -28,8 +28,6 @@ function ngStyle(opts) {
 
         sass.render({
             data: file.contents.toString(),
-            success: success,
-            error: error,
             includePaths: paths,
             imagePath: module.imagePath,
             // outputStyle: 'compressed'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "gulp": "^3.8.11",
     "jshint": "^2.6.3",
     "lodash.template": "3.6.0",
-    "node-sass": "^2.0.1",
+    "node-sass": "^4.9.3",
     "rcfinder": "^0.1.8",
     "through2": "^0.6.3",
     "vinyl": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-build",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "main": "lib/index.js",
   "dependencies": {
     "acorn": "^0.12.0",


### PR DESCRIPTION
```
render Callback (>= v3.0.0)
node-sass supports standard node style asynchronous callbacks with the signature of function(err, result). In error conditions, the error argument is populated with the error object. In success conditions, the result object is populated with an object describing the result of the render call.
```